### PR TITLE
fix(enrichment): avoid overwriting dataset properties

### DIFF
--- a/feature/enrichment/properties_service.py
+++ b/feature/enrichment/properties_service.py
@@ -2,8 +2,7 @@
 import logging
 from typing import Dict, Any
 from .base_enrichment_service import BaseEnrichmentService
-from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.metadata.schema_classes import DatasetPropertiesClass
+from datahub.emitter.mcp_patch_builder import MetadataPatchProposal
 
 logger = logging.getLogger(__name__)
 
@@ -20,15 +19,30 @@ class PropertiesService(BaseEnrichmentService):
         target_urn = None
         try:
             target_urn = self._build_urn(config["data_type"], config["dataset_name"])
-            
-            properties_aspect = DatasetPropertiesClass(
-                name=config.get("name"),
-                description=config.get("description"),
-                customProperties=config.get("custom_properties")
-            )
-            
-            mcp = MetadataChangeProposalWrapper(entityUrn=target_urn, aspect=properties_aspect)
-            self.platform_handler.emit_mcp(mcp)
+
+            test_mode = bool(getattr(self.platform_handler, "test_mode", False))
+            if config.get("dry_run") or test_mode:
+                logger.info(f"DRY_RUN/TEST_MODE: would submit properties update for URN: {target_urn}")
+                return True
+
+            # Use patch-style updates to avoid clearing other DatasetProperties fields.
+            patch = MetadataPatchProposal(urn=target_urn)
+
+            if "name" in config and config.get("name") is not None:
+                patch._add_patch("datasetProperties", "add", ("name",), config.get("name"))
+
+            if "description" in config and config.get("description") is not None:
+                patch._add_patch("datasetProperties", "add", ("description",), config.get("description"))
+
+            custom_props = config.get("custom_properties") or {}
+            if not isinstance(custom_props, dict):
+                raise ValueError("'custom_properties' must be a dict of str->str")
+
+            for k, v in custom_props.items():
+                patch._add_patch("datasetProperties", "add", ("customProperties", str(k)), str(v))
+
+            for mcp in patch.build():
+                self.platform_handler.emit_mcp(mcp)
             
             logger.info(f"Successfully submitted properties update for URN: {target_urn}")
             return True

--- a/tests/unit/test_enrichment_services.py
+++ b/tests/unit/test_enrichment_services.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datahub.metadata.schema_classes import ChangeTypeClass
+
+from feature.enrichment.description_service import DescriptionService
+from feature.enrichment.properties_service import PropertiesService
+
+
+class _DummyConfigManager:
+    def get_global_config(self):
+        return {"default_env": "DEV"}
+
+
+class _DummyPlatformHandler:
+    def __init__(self, *, test_mode: bool = False):
+        self.test_mode = test_mode
+        self.mcps = []
+
+    def emit_mcp(self, mcp):
+        self.mcps.append(mcp)
+
+
+def test_description_service_emits_patch_mcp() -> None:
+    ph = _DummyPlatformHandler()
+    svc = DescriptionService(ph, _DummyConfigManager())
+    ok = svc.enrich({"data_type": "csv", "dataset_name": "d", "description": "hello"})
+    assert ok is True
+    assert len(ph.mcps) == 1
+    assert ph.mcps[0].changeType == ChangeTypeClass.PATCH
+    assert ph.mcps[0].aspectName == "datasetProperties"
+
+
+def test_description_service_dry_run_does_not_emit() -> None:
+    ph = _DummyPlatformHandler()
+    svc = DescriptionService(ph, _DummyConfigManager())
+    ok = svc.enrich({"data_type": "csv", "dataset_name": "d", "description": "hello", "dry_run": True})
+    assert ok is True
+    assert ph.mcps == []
+
+
+def test_properties_service_emits_patch_mcp() -> None:
+    ph = _DummyPlatformHandler()
+    svc = PropertiesService(ph, _DummyConfigManager())
+    ok = svc.enrich({"data_type": "csv", "dataset_name": "d", "name": "d", "custom_properties": {"a": "1"}})
+    assert ok is True
+    assert len(ph.mcps) == 1
+    assert ph.mcps[0].changeType == ChangeTypeClass.PATCH
+    assert ph.mcps[0].aspectName == "datasetProperties"
+
+
+def test_properties_service_dry_run_does_not_emit() -> None:
+    ph = _DummyPlatformHandler()
+    svc = PropertiesService(ph, _DummyConfigManager())
+    ok = svc.enrich(
+        {"data_type": "csv", "dataset_name": "d", "name": "d", "custom_properties": {"a": "1"}, "dry_run": True}
+    )
+    assert ok is True
+    assert ph.mcps == []
+
+
+def test_properties_service_rejects_non_dict_custom_properties() -> None:
+    ph = _DummyPlatformHandler()
+    svc = PropertiesService(ph, _DummyConfigManager())
+    assert svc.enrich({"data_type": "csv", "dataset_name": "d", "custom_properties": ["nope"]}) is False  # type: ignore[list-item]
+
+


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a clear and concise description of what this PR does -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition/update
- [ ] 🔧 Build/config change

## Related Issues
<!-- Required: link this PR to the issue implied by your branch name -->
<!-- Use ONE of the following (preferred: Closes/Fixes/Resolves) -->
- Fixes #23 

## Changes Made
Updated feature/enrichment/description_service.py
Uses MetadataPatchProposal to patch only datasetProperties.description
Adds dry_run / test_mode guard so it can be exercised safely
Updated feature/enrichment/properties_service.py
Uses MetadataPatchProposal to patch only the provided fields + individual customProperties keys
Validates custom_properties must be a dict
Adds dry_run / test_mode
Added unit tests tests/unit/test_enrichment_services.py
Asserts emitted MCPs are PATCH and target datasetProperties
Verifies dry_run doesn’t emit

## Testing
<!-- Describe the testing you've done -->
- [ ] ✅ Unit tests added/updated
- [ ] ✅ Integration tests added/updated
- [ ] ✅ Manual testing performed
- [ ] ✅ All tests pass locally
- [ ] ✅ Pre-commit hooks pass
- [ ] ✅ Code coverage maintained/improved

## Code Quality Checklist
<!-- All items must be checked before requesting review -->
- [x] ✅ Code follows project style guidelines (Black, Ruff)
- [x] ✅ Self-review completed
- [ ] ✅ Code is commented, particularly in hard-to-understand areas
- [ ] ✅ Type hints added where appropriate
- [ ] ✅ Docstrings added for public functions/classes
- [ ] ✅ No new warnings generated
- [x] ✅ Branch naming follows convention (`feature/`, `fix/`, `docs/`, etc.)
- [ ] ✅ Commit messages follow Conventional Commits format
- [x] ✅ Branch is up to date with main/develop

--
**Note**: This PR will be automatically checked by:
- ✅ Pre-commit hooks (branch naming, commit messages, formatting)
- ✅ GitHub Actions CI (linting, type checking, tests, coverage)
- ✅ Security scanning (Bandit, Ruff security checks)

