### PR TITLE
docs(vision): add comprehensive vision documentation set

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 A comprehensive, enterprise-ready Python framework for **ingesting metadata**, **managing ownership**, **enriching datasets**, **tracking lineage**, **versioning**, and **extracting analytics** from DataHub. Built with SOLID principles and modular architecture for maximum extensibility and maintainability.
 
+## 🧭 Vision & Documentation
+
+- [Documentation index](docs/README.md) - Audience-based entry points (CTO/CEO, engineering, OSS contributors)
+- [Vision set (recommended order)](docs/vision/README.md) - Full executive narrative, roadmap, architecture vision
+- [Executive summary](docs/vision/00_executive_summary.md) - Fast overview for leaders
+
 ## 🚀 Key Features
 
 ### 👤 **Ownership Management** ⭐ NEW
@@ -482,7 +488,7 @@ class MyCustomHandler(BaseIngestionHandler):
     def _get_schema_fields(self) -> List[SchemaFieldClass]:
         # Implement schema extraction logic
         pass
-    
+
     def _get_raw_schema(self) -> str:
         # Return raw schema representation
         pass


### PR DESCRIPTION
## Summary

Add the canonical vision documentation set for Lumos, organized for CTOs, engineers, and OSS contributors.

## Changes

### New Files (18 total)

- `docs/README.md` - Documentation index organized by audience
- `docs/vision/README.md` - Recommended reading order
- `docs/vision/00_executive_summary.md` - CTO-level overview, the $50B metadata problem
- `docs/vision/01_problem_statement.md` - Detailed problem analysis
- `docs/vision/02_product_definition.md` - What Lumos is
- `docs/vision/03_solution_overview.md` - How it solves the problem
- `docs/vision/04_architecture_vision.md` - Technical architecture
- `docs/vision/05_roadmap.md` - Phased roadmap (A-F) with priorities
- `docs/vision/06_implementation_status.md` - Honest status of all components
- `docs/vision/07_competitive_analysis.md` - Market positioning
- `docs/vision/08_business_value.md` - ROI and value proposition
- `docs/vision/09_detailed_plan.md` - Implementation details
- `docs/vision/10_ai_roadmap.md` - Future AI capabilities
- `docs/vision/11_demo_script.md` - Demo walkthrough
- `docs/vision/12_migration_guide.md` - Migration guidance
- `docs/vision/13_cost_attribution.md` - FinOps features
- `docs/vision/14_cost_management.md` - Cost management
- `docs/vision/15_assessment_report.md` - Gap analysis

## Highlights

- **6,782 lines** of comprehensive documentation
- Organized by **audience**: CTO/CEO, Engineering, OSS contributors
- Clear **reading order** for different stakeholders
- Honest **implementation status** with real coverage numbers
- **Phased roadmap** (A-F) with deliverables and acceptance criteria

Closes #18